### PR TITLE
Build container image from CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,20 +1,17 @@
 elifePipeline {
-    def commit
-    def schemaVersion
     def tag
     DockerImage image
 
     node('containers-jenkins-plugin') {
         stage 'Checkout', {
             checkout scm
-            commit = elifeGitRevision()
+            def commit = elifeGitRevision()
             def commitShort = commit.substring(0, 8)
-            schemaVersion = params.SCHEMA_VERSION ?: "master"
-            tag = "${commitShort}-${schemaVersion}"
+            tag = "${commitShort}-${params.SCHEMA_VERSION}"
         }
 
         stage 'Build', {
-            dockerBuild('basex-validator', commit, null, 'elifesciences', ['schema_version':schemaVersion])
+            dockerBuild('basex-validator', tag, null, 'elifesciences', ['schema_version':params.SCHEMA_VERSION])
         }
 
     //    stage 'Tests', {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,41 @@
+elifePipeline {
+    def commit
+    def commitShort
+    def schemaVersion
+    def tag
+    DockerImage image
+
+    node('containers-jenkins-plugin') {
+        stage 'Checkout', {
+            checkout scm
+            commit = elifeGitRevision()
+            commitShort = sh(script: "git rev-parse --short HEAD", returnStdout: true).trim()
+            schemaVersion = params.'SCHEMA_VERSION' ?: "master"
+            tag = "${commitShort}-${schemaVersion}"
+        }
+
+        stage 'Build', {
+            sh "docker-wait-daemon"
+            def imageName = "elifesciences/basex-validator"
+            def dockerfile = 'Dockerfile'
+            sh "docker build --pull -f ${dockerfile} -t ${imageName}:${tag} . --build-arg schema_version=${schemaVersion}"
+        }
+
+    //    stage 'Tests', {
+    //         dockerComposeProjectTests('digests', commit, ['/srv/digests/build/*.xml'])
+    //         dockerComposeSmokeTests(commit, [
+    //             'scripts': [
+    //                 'wsgi': './smoke_tests_wsgi.sh',
+    //             ],
+    //         ])
+    //    }
+
+        elifeMainlineOnly {
+            stage 'Publish', {
+                image = DockerImage.elifesciences(this, 'basex-validator', tag)
+                image.push()
+                image.tag('latest').push()
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
 elifePipeline {
     def tag
+    def schemaVersion
     DockerImage image
 
     node('containers-jenkins-plugin') {
@@ -7,11 +8,12 @@ elifePipeline {
             checkout scm
             def commit = elifeGitRevision()
             def commitShort = commit.substring(0, 8)
-            tag = "${commitShort}-${params.SCHEMA_VERSION}"
+            schemaVersion = params.schemaVersion ?: 'master'
+            tag = "${commitShort}-${schemaVersion}"
         }
 
         stage 'Build', {
-            dockerBuild('basex-validator', tag, null, 'elifesciences', ['schema_version':params.SCHEMA_VERSION])
+            dockerBuild('basex-validator', tag, null, 'elifesciences', ['schema_version': schemaVersion])
         }
 
     //    stage 'Tests', {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,5 @@
 elifePipeline {
     def commit
-    def commitShort
     def schemaVersion
     def tag
     DockerImage image
@@ -9,16 +8,13 @@ elifePipeline {
         stage 'Checkout', {
             checkout scm
             commit = elifeGitRevision()
-            commitShort = sh(script: "git rev-parse --short HEAD", returnStdout: true).trim()
-            schemaVersion = params.'SCHEMA_VERSION' ?: "master"
+            def commitShort = commit.substring(0, 8)
+            schemaVersion = params.SCHEMA_VERSION ?: "master"
             tag = "${commitShort}-${schemaVersion}"
         }
 
         stage 'Build', {
-            sh "docker-wait-daemon"
-            def imageName = "elifesciences/basex-validator"
-            def dockerfile = 'Dockerfile'
-            sh "docker build --pull -f ${dockerfile} -t ${imageName}:${tag} . --build-arg schema_version=${schemaVersion}"
+            dockerBuild('basex-validator', commit, null, 'elifesciences', ['schema_version':schemaVersion])
         }
 
     //    stage 'Tests', {


### PR DESCRIPTION
Add support for building and publishing the basex-validator container from Jenkins. 

Probably worth explaining a bit what is going on. This builds a container that comprises of the contents of this repo merged with the specified version of the schematron files from the eLife-JATS-schematron project.

The version of the schematron that you want to merge is passed in as a 'build-arg' whilst building the container, which allows me to 'hook' that up to a parameter in Jenkins which can be passed through via an upstream project (yet to be configured), but for now you can 'manually' trigger a build setting the param to the commit ref you want to merge.

Note: that there isn't any support in the dockerBuild scripts for passing build args through to docker build, hence the sort of custom build step. And for tagging the container, I use the short commit ref for this repo, and append the commit ref from the schematron version, e.g...

<short commit ref>-<upstream commit ref>

Which comes out like...

74e6774-4022dacfac35acc4b3e25fd876a2ef34dba6aea3

I did think that I could just do this in the eLife-JATS-schematron project, and not worry about the above. But those files are likely to be pulled into other projects as well and hence I think this container should be in a separate repo.
