### PR TITLE
Use custom json-escape function for errors

### DIFF
--- a/src/webapp/validator.xqm
+++ b/src/webapp/validator.xqm
@@ -89,7 +89,7 @@ declare function e:svrl2json($svrl){
                 '{',
                 ('"path": "'||$error/@location/string()||'",'),
                 ('"type": "'||$error/@role/string()||'",'),
-                ('"message": "'||replace(normalize-space($error/*:text[1]/data()),'"','\\"')||'"'),
+                ('"message": "'||e:json-escape($error/*:text[1]/data())||'"'),
                 '}'
               )
           ,','),


### PR DESCRIPTION
- Ensure `\` characters are escaped in error messages in order to correctly parse json.