### PR TITLE
improvement: better handling of message links

### DIFF
--- a/src/repo/http-github.com-Schematron-schematron-basex-1.2/content/iso-schematron/iso_svrl_for_xslt2.xsl
+++ b/src/repo/http-github.com-Schematron-schematron-basex-1.2/content/iso-schematron/iso_svrl_for_xslt2.xsl
@@ -185,7 +185,7 @@ THE SOFTWARE.
 		<xsl:otherwise>#ALL</xsl:otherwise>
 	</xsl:choose>
 </xsl:param>
-<xsl:param name="allow-foreign">false</xsl:param>
+<xsl:param name="allow-foreign">true</xsl:param>
 <xsl:param name="generate-paths">true</xsl:param>
 <xsl:param name="generate-fired-rule">true</xsl:param>
 <xsl:param name="optimize" />

--- a/src/webapp/validator.xqm
+++ b/src/webapp/validator.xqm
@@ -92,7 +92,7 @@ declare function e:svrl2json($svrl){
                 '{',
                 ('"path": "'||$error/@location/string()||'",'),
                 ('"type": "'||$error/@role/string()||'",'),
-                ('"message": "'||e:json-escape($error/*:text[1]/data())||'"'),
+                ('"message": "'||e:get-message($error)||'"'),
                 '}'
               )
           ,','),
@@ -107,7 +107,7 @@ let $warnings :=
                 '{',
                 ('"path": "'||$warn/@location/string()||'",'),
                 ('"type": "'||$warn/@role/string()||'",'),
-                ('"message": "'||e:json-escape($warn/*:text[1]/data())||'"'),
+                ('"message": "'||e:get-message($warn)||'"'),
                 '}'
               )
           ,','),
@@ -151,7 +151,7 @@ declare function e:svrl2json-final($xml,$svrl){
                 '{',
                 ('"path": "'||$error/@location/string()||'",'),
                 ('"type": "'||$error/@role/string()||'",'),
-                ('"message": "'||e:json-escape($error/*:text[1]/data())||'"'),
+                ('"message": "'||e:get-message($error)||'"'),
                 '}'
               )
           ,',')
@@ -174,7 +174,7 @@ let $warnings :=
                 '{',
                 ('"path": "'||$warn/@location/string()||'",'),
                 ('"type": "'||$warn/@role/string()||'",'),
-                ('"message": "'||e:json-escape($warn/*:text[1]/data())||'"'),
+                ('"message": "'||e:get-message($warn)||'"'),
                 '}'
               )
           ,','),
@@ -195,6 +195,11 @@ return json:parse($json)
 
 declare function e:json-escape($string){
   normalize-space(replace(replace($string,'\\','\\\\'),'"','\\"'))
+};
+
+declare function e:get-message($node){
+  if ($node[@see]) then (e:json-escape(data($node))||' <a href=\"'||$node/@see||'\">'||$node/@see||'</a>')
+  else e:json-escape(data($node))
 };
 
 declare function e:update-refs($schema,$path2schema){


### PR DESCRIPTION
- Set `allow-foreign` param in iso xslt to true, permitting see attributes in svrl.
- json output now contains `<a/>` element with link instead of text.