### PR TITLE
fix: see attribute links as plain text

### DIFF
--- a/src/webapp/validator.xqm
+++ b/src/webapp/validator.xqm
@@ -198,7 +198,7 @@ declare function e:json-escape($string){
 };
 
 declare function e:get-message($node){
-  if ($node[@see]) then (e:json-escape(data($node))||' <a href=\"'||$node/@see||'\">'||$node/@see||'</a>')
+  if ($node[@see]) then e:json-escape((data($node)||' '||$node/@see))
   else e:json-escape(data($node))
 };
 


### PR DESCRIPTION
- Post see attribute links as plain text instead of as `<a>` element.