### PR TITLE
Surface see attribute values placed on `svrl:text` elements

### DIFF
--- a/src/webapp/svrl-converter.xqm
+++ b/src/webapp/svrl-converter.xqm
@@ -193,6 +193,7 @@ declare function svrl:svrl2result-video($xml,$svrl) as element(div)*
 declare function svrl:get-table-rows($svrl) as element(tr)* {
   for $x at $p in $svrl//*[@role=('error','warn','warning','info')]
     let $id-content := if ($x/@see) then <a href="{$x/@see/string()}" target="_blank">{$x/@id/string()}</a>
+                       else if ($x/*:text/@see) then <a href="{$x/*:text[1]/@see/string()}" target="_blank">{$x/@id/string()}</a>
                   else $x/@id/string()
     let $type := (upper-case(substring($x/@role,1,1))||substring($x/@role,2))
     let $class := if ($p mod 2 = 0) then ($x/@role||' even') else ($x/@role||' odd')

--- a/src/webapp/utilities.xqm
+++ b/src/webapp/utilities.xqm
@@ -7,6 +7,7 @@ declare function util:json-escape($string){
 
 declare function util:get-message($node){
   if ($node[@see]) then util:json-escape((data($node)||' '||$node/@see))
+  else if ($node/*:text[@see]) then util:json-escape((data($node)||' '||$node/*:text[1]/@see))
   else util:json-escape(data($node))
 };
 


### PR DESCRIPTION
schxslt2 places the attribute on the `svrl:text` instead of the `svrl:successful-report` or `svrl:failed-assert`